### PR TITLE
Feat: add armadillo as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "cpp/ext/armadillo"]
+	path = cpp/ext/armadillo
+	url = https://gitlab.com/conradsnicta/armadillo-code
+	branch = 14.4.x

--- a/README.md
+++ b/README.md
@@ -47,3 +47,11 @@ print(change_points)
 ```bash
 [1] 2 6
 ```
+
+
+## Developer zone
+
+**Which Armadillo version is used?**
+
+Armadillo is added to the project's dependencies as a git submodule in `cpp/ext/armadillo`.
+The submodule is linked to the [Armadillo repo](https://gitlab.com/conradsnicta/armadillo-code) and is pinned to version 14.4.x


### PR DESCRIPTION
Instead of asking users to install armadillo themselves, we use git submodules as a poor man's package manager.

Armadillo is added to the project's dependencies as a git submodule in `cpp/ext/armadillo`.
The submodule is linked to the [Armadillo repo](https://gitlab.com/conradsnicta/armadillo-code) and is pinned to version 14.4.x
